### PR TITLE
Fix: default를 넣고 상대방의 경기정보가 넘어오지 않는 경우 early return

### DIFF
--- a/src/useCases/changeServerDataIntoRenderData.ts
+++ b/src/useCases/changeServerDataIntoRenderData.ts
@@ -29,6 +29,7 @@ export const changeServerDataIntoRenderData = (
   matchDetailData: IMatchDetailData,
   userNickName: string,
 ) => {
+  // 여기서 matchDetailData가 예상과 다르게 들어와도 default 상태를 정의해주면 문제없이 동작할 것으로 보인다.
   const newState: IViewData = {
     matchType: '',
     matchResult: '',
@@ -36,7 +37,8 @@ export const changeServerDataIntoRenderData = (
     leftPlayer: {
       nickName: '',
       goalCount: 0,
-      possession: 0,
+      // 🟡: 유저의 닉네임이 들어갈만한 최소 공간(점유율)
+      possession: 70,
       bestPlayer: {
         id: 0,
         name: '',
@@ -45,9 +47,11 @@ export const changeServerDataIntoRenderData = (
       },
     },
     rightPlayer: {
-      nickName: '',
+      // 🟡: string type의 defualt 닉네임
+      nickName: '무명유저',
       goalCount: 0,
-      possession: 0,
+      // 🟡: 유저의 닉네임이 들어갈만한 최소 공간(점유율)
+      possession: 30,
       bestPlayer: {
         id: 0,
         name: '',
@@ -55,7 +59,13 @@ export const changeServerDataIntoRenderData = (
         spId: 0,
       },
     },
-    matchDetails: [{}, {}] as MatchInfo[],
+    matchDetails: [
+      {},
+      {
+        // 🟡: MatchInfo[] 형식의 defautl data를 넣어줌
+        player: [{}],
+      },
+    ] as MatchInfo[],
   };
   // 시간변환
   newState.matchDate = changeDateUtil(matchDetailData.matchDate);
@@ -64,6 +74,18 @@ export const changeServerDataIntoRenderData = (
 
   // 기권패인 경우에는 관련 값들이 빈상태로 오는 경우도 존재한다.
   // 몰수패는 어떻게 보여줄꺼야....
+
+  if (matchDetailData.matchInfo.length === 1) {
+    const searcherData = matchDetailData.matchInfo[0];
+
+    newState.matchDetails[0] = searcherData;
+    newState.leftPlayer.bestPlayer.spId = pickBestPlayer(searcherData).spId;
+    newState.leftPlayer.goalCount = searcherData.shoot.goalTotal;
+    newState.leftPlayer.nickName = searcherData.nickname;
+    newState.matchResult = searcherData.matchDetail.matchResult;
+
+    return newState;
+  }
 
   if (userNickName === matchDetailData.matchInfo[1].nickname) {
     const sercherData = matchDetailData.matchInfo[1];


### PR DESCRIPTION
### 작업내용
- Fix: 결기결과 데이터를 요청 시 '상대방의 경기 결과 데이터'가 넘어오지 않아 생기는 클라이언트 측 에러를 해결하였습니다.
- 자세한 __에러 트래킹__ 은 #19 를 통해 확인하실 수 있습니다.